### PR TITLE
II-14396 - Update the Actian.EFCore to use Microsoft.EntityFrameworkCore 3.1.32.

### DIFF
--- a/src/Actian.EFCore/Actian.EFCore.csproj
+++ b/src/Actian.EFCore/Actian.EFCore.csproj
@@ -12,7 +12,7 @@
     <Description>Actian Entity Framework Core Provider</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <MinClientVersion>4.3</MinClientVersion>
 
     <RepositoryType>git</RepositoryType>
@@ -52,10 +52,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="3.1.10" />
-    <PackageReference Include="Actian.Client" Version="3.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="3.1.32" />
+    <PackageReference Include="Actian.Client" Version="3.0.2" />
     <PackageReference Include="Sprache" Version="2.3.0" />
   </ItemGroup>
 

--- a/utils/Actian.EFCore.Build/Actian.EFCore.Build.csproj
+++ b/utils/Actian.EFCore.Build/Actian.EFCore.Build.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Actian.Client" Version="3.0.1" />
+    <PackageReference Include="Actian.Client" Version="3.0.2" />
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="Sprache" Version="2.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />


### PR DESCRIPTION
Update the Actian.EFCore to use Microsoft.EntityFrameworkCore 3.1.32, bump the version to 3.1.1 and Actian.Client dependency to Version 3.0.2.