### PR TITLE
use correct framework

### DIFF
--- a/src/Actian.EFCore/Actian.EFCore.csproj
+++ b/src/Actian.EFCore/Actian.EFCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Entity Framework Core provider for Actian</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- There's lots of use of internal EF Core APIs from the tests, suppress the analyzer warnings for those -->
     <NoWarn>$(NoWarn);xUnit1003;xUnit1004;xUnit1013;EF1001</NoWarn>
   </PropertyGroup>

--- a/utils/Actian.EFCore.Build/Actian.EFCore.Build.csproj
+++ b/utils/Actian.EFCore.Build/Actian.EFCore.Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)